### PR TITLE
Client public interface

### DIFF
--- a/lib/manageiq-messaging.rb
+++ b/lib/manageiq-messaging.rb
@@ -1,2 +1,1 @@
 require 'manageiq/messaging'
-

--- a/lib/manageiq/messaging/client.rb
+++ b/lib/manageiq/messaging/client.rb
@@ -1,32 +1,121 @@
 module ManageIQ
   module Messaging
     class Client
+      # Open or create a connection to the message broker
+      # @param options [Hash] the connection options
+      # @return [Client, nil] the client object if no block is given
+      #   The optional block supply {|client| block }. The client will
+      #   be automatically closed when the block terminates
       def self.open(options)
-        StompClient.new(options)
+        # TODO: replace with a AMQP client
+        client = StompClient.new(options)
+        return client unless block_given?
+        if block_given?
+          yield client
+          client.close
+          nil
+        end
       end
 
-      def publish_background_job(options)
-        BackgroundJob.push(self, options)
-      end
-
-      def subscribe_background_job(options)
-        BackgroundJob.subscribe(self, options)
-      end
-
-      def publish_queue(options)
+      # Publish to a message to a queue. The message will be delivered to only one
+      # subscriber.
+      # @param options [Hash] the message attributes. Expected keys are:
+      #   :service    (service and affinity are used to determine the queue name)
+      #   :affinity   (optional)
+      #   :class_name (optional)
+      #   :message (e.g. method_name or message type)
+      #   :payload (user defined structure, following are some examples)
+      #     :instance_id
+      #     :args
+      #     :miq_callback
+      #   :sender    (optional, type of the publisher)
+      #   :sender_id (optional, identity of the publisher)
+      #   <other queue options TBA>
+      #
+      def publish_message(options)
         Queue.publish(self, options)
       end
 
-      def subscribe_queue(options, &block)
+      # Publish multiple messages to a queue.
+      # An aggregate version of `#publish_message `but for better performance
+      # All messages are sent in a batch
+      #
+      # @param messages [Array] a collection of options for `#publish_message`
+      def publish_messages(messages)
+        Queue.publish_batch(self, messages)
+      end
+
+      # Subscribe to receive messages from a queue
+      #
+      # @param options [Hash] attributes to configure how to receive messages.
+      #  Available keys are:
+      #   :service  (service and affinity are used to determine the queue)
+      #   :affinity (optional)
+      #   :limit    (optional, receives up to limit messages into the buffer)
+      #
+      # A callback block {|messages| block} needs to be provided to consume the
+      # messages. Example
+      #   subscribe_message(options) do |messages|
+      #     messages.each do |msg|
+      #       # from msg you get
+      #       msg.sender
+      #       msg.message
+      #       msg.payload
+      #       msg.ack_id (used to ack the message)
+      #     end
+      #   end
+      #
+      # @note The subscriber should ack each message independently in the callback
+      # block. It can decide when to ack according to whether a message can
+      # be retried. Ack the message in the beginning of processing if the
+      # message is not re-triable; otherwise ack it after the message is done.
+      # Any un-acked message will be redelivered to next subscriber AFTER the
+      # current subscriber disconnects normally or abnormally (e.g. crashed).
+      # Make sure a message is properly acked whatever strategy you take.
+      #
+      # To ack a message call `ack(msg.ack_id)`
+      def subscribe_messages(options, &block)
         raise "A block is required" unless block_given?
 
         Queue.subscribe(self, options, &block)
       end
 
+      # Subscribe to receive from a queue and run each message as a background job.
+      # @param options [Hash] attributes to configure how to receive messages
+      #   :service  (service and affinity are used to determine the queue)
+      #   :affinity (optional)
+      #
+      # This subscriber works only if the incoming message includes the class_name option
+      #
+      # Background job assumes each job is not re-triable. It will ack as soon as a request
+      # is received
+      def subscribe_background_job(options)
+        BackgroundJob.subscribe(self, options)
+      end
+
+      # Publish a message as a topic. All subscribers will receive a copy of the message.
+      # @param options [Hash] the message attributes. Expected keys are:
+      #   :service   (service is used to determine the topic address)
+      #   :event     (event name)
+      #   :payload   (user defined structure that describes the event)
+      #   :sender    (optional, type of the publisher)
+      #   :sender_id (optional, identity of the publisher)
+      #   <other queue options TBA>
+      #
       def publish_topic(options)
         Topic.publish(self, options)
       end
 
+      # Subscribe to receive topic type messages.
+      # @param options [Hash] attributes to configure how to receive messages
+      #   :service    (service is used to determine the topic address)
+      #   :persist_id (optional, client needs to be have client_id to use this feature)
+      #
+      # Persisted event: In order to consume events missed during the period when the client is
+      # offline, the subscriber needs to be reconnect always with the same client_id and persist_id
+      #
+      # A callback {|sender, event, payload| block } needs to be provided to consume the topic
+      #
       def subscribe_topic(options, &block)
         raise "A block is required" unless block_given?
 

--- a/lib/manageiq/messaging/queue.rb
+++ b/lib/manageiq/messaging/queue.rb
@@ -6,31 +6,34 @@ module ManageIQ
       def self.publish(client, options)
         assert_options(options, [:message, :service])
 
-        options = options.dup
         address, headers = queue_for_publish(options)
-        headers[:sender] = options.delete(:sender) if options[:sender]
-        headers[:message_type] = options.delete(:message_type) if options[:message_type]
+        headers[:sender] = options[:sender] if options[:sender]
+        headers[:message_type] = options[:message] if options[:message]
+        headers[:class_name] = options[:class_name] if options[:class_name]
 
-        raw_publish(client, address, options[:message], headers)
+        raw_publish(client, address, options[:payload] || '', headers)
       end
+
+      def self.publish_batch(client, messages)
+        messages.each { |options| publish(client, options) }
+      end
+
+      Struct.new("Message", :sender, :message, :payload, :ack_id)
 
       def self.subscribe(client, options)
         assert_options(options, [:service])
 
-        options = options.dup
         queue_name, headers = queue_for_subscribe(options)
 
+        # for STOMP we can get message one at a time
         client.subscribe(queue_name, headers) do |msg|
-          begin
-            sender = msg.headers['sender']
-            message_type = msg.headers['message_type']
-            message_body = decode_body(msg.headers, msg.body)
-            logger.info("Message received: queue(#{queue_name}), msg(#{message_body}), headers(#{msg.headers})")
-            yield sender, message_type, message_body
-            logger.info("Message processed")
-          ensure
-            client.ack(msg)
-          end
+          sender = msg.headers['sender']
+          message_type = msg.headers['message_type']
+          message_body = decode_body(msg.headers, msg.body)
+          logger.info("Message received: queue(#{queue_name}), msg(#{message_body}), headers(#{msg.headers})")
+
+          yield [Struct::Message.new(sender, message_type, message_body, msg)]
+          logger.info("Message processed")
         end
       end
     end

--- a/lib/manageiq/messaging/stomp_client.rb
+++ b/lib/manageiq/messaging/stomp_client.rb
@@ -10,20 +10,21 @@ module ManageIQ
       attr_reader :stomp_client
 
       # options
-      #   :hosts (array of)
-      #     :host
-      #     :login
-      #     :passcode
-      #     :port
+      #   :host
+      #   :username
+      #   :password
+      #   :port
       #   :client_id (optional)
-      #   :heartbeat  (default to true)
+      #   :heartbeat (optional, default to true)
       def initialize(options)
-        hosts = options[:hosts]
+        host = {:host => options[:host], :port => options[:port]}
+        host[:passcode] = options[:password] if options[:password]
+        host[:login] = options[:username] if options[:username]
         headers = {}
-        headers.merge!(:host => hosts[0][:host], :"accept-version" => "1.2", :"heart-beat" => "2000,0") if options[:heartbeat]
+        headers.merge!(:host => options[:host], :"accept-version" => "1.2", :"heart-beat" => "2000,0") unless options[:heartbeat] == false
         headers.merge!(:"client-id" => options[:client_id]) if options[:client_id]
 
-        @stomp_client = Stomp::Client.new(:hosts => hosts, :connect_headers => headers)
+        @stomp_client = Stomp::Client.new(:hosts => [host], :connect_headers => headers)
       end
     end
   end


### PR DESCRIPTION
# Design overview:

`ManageIQ::Messaging::Client.open(options)` returns a client object that is used to send or receive messages. This allows to swap the actual client implementation. Currently STOMP client is the only implementation, to be replaced by an AMQP client soon.

## Send
```
  client.publish_message(options)
  client.publish_topic(options)
  client.publish_messages(messages)
```
A client can publish either a message (1-to-1) or a topic (1-to-many). `client.publish_messages` is a batch send. It is not just a convenience method but may help the performance. It is not manifested with STOMP client, but an AMQP client it can accumulate multiple messages and finish with one send.

We can argue whether to provide a `client.publish_topics` method. I don't see it is common when something happens a provider needs to publish multiple events.

## Receive
```
  client.subscribe_background_job(options)

  client.subscribe_messages(options) do |messages|
  end

  client.subscribe_topic(options) do |sender, event, payload|
  end
```
Background job is a special type of message where the class name and method name are known. The subscriber therefore knows how to consume the message without caller to provide additional logic. We talked about the enhancement to use a white list to filter only allowed method to be executed. It is a feature to be done in future work.

Regular messages need user to provide logic with a block. We talked about the other approach by receiving a handle in the argument. I personally prefer the style to use callback block, like other clients such as [kafka](https://github.com/zendesk/ruby-kafka#consuming-messages-from-kafka) and [stomp](https://github.com/stompgem/stomp)

`client.subscribe_messages` takes an option to limit the number of messages to be processed as a batch. This allows optimization by consumer. It is the only method that requires user code to ack the message. User needs to ack each message pre or post processing which allow any unprocessed messages to be redelivered should the worker abort abnormally.

Normally a topic subscribes needs to be online in order to receive events. Any events sent when a subscriber is offline are dropped. ActiveMQ Artemis allows to configure the events to be persisted when a topic subscriber is offline. To do so `client.subscribe_topic` accepts `persist_id` in the `options`, and the client also needs to be created with a user specified `client_id`.